### PR TITLE
Avoid "Resource not accessible by integration" cleanup job failure

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           environment: "pr-${{ github.event.number }}"
           token: ${{ secrets.GITHUB_TOKEN }}
+          onlyRemoveDeployments: true


### PR DESCRIPTION
workaround to prevent failures like [this ](https://github.com/SteeltoeOSS/InitializrWeb/actions/runs/13548979350)

We'll have empty github environments left behind as a result, which could require cleanup at some future date, but I don't think there's any impact besides useless entries [here](https://github.com/SteeltoeOSS/InitializrWeb/settings/environments) -- the alternative is granting the workflow greater permissions 